### PR TITLE
Fixed sensorbus adressing issue

### DIFF
--- a/src/mj.cpp
+++ b/src/mj.cpp
@@ -111,6 +111,7 @@ sensorInterface MujocoModelInstance::getSensorInterface()
         char *namePointer = m->names + m->name_sensoradr[index];
         std::string str(namePointer);
         names.push_back(str);
+        
     }
     si.names = names;
 
@@ -123,14 +124,7 @@ sensorInterface MujocoModelInstance::getSensorInterface()
         si.scalarCount += sensor_dim;
     }
     si.dim = dim;
-
-    std::vector<unsigned> addr;
-    for (unsigned index = 0; index < si.count; index++)
-    {
-        unsigned sensor_addr = m->sensor_adr[index];
-        addr.push_back(sensor_addr);
-    }
-    si.addr = addr;
+ // Sensor adressing part removed.
     return si;
 }
 
@@ -198,17 +192,17 @@ void MujocoModelInstance::step(std::vector<double> u)
     dMutex.unlock();
 }
 
-std::vector<double> MujocoModelInstance::getSensor(unsigned index)
+std::vector<double> MujocoModelInstance::getSensor()
 {
     std::vector<double> sensorData;
 
     dMutex.lock();
-    auto addrStart = si.addr[index];
-    auto addrEnd = addrStart + si.dim[index] - 1;
-    for (unsigned i = addrStart; i <= addrEnd; i++)
+
+    for (unsigned i = 0; i < si.count; i++)
     {
         sensorData.push_back(d->sensordata[i]);
     }
+
     dMutex.unlock();
     return sensorData;
 }
@@ -489,6 +483,7 @@ void MujocoGUI::refreshScene(MujocoModelInstance* mi)
         glfwGetFramebufferSize(window, &viewport.width, &viewport.height);
     }
     mi->dMutex.lock(); // lock before using simulation data
+    
     mjv_updateScene(mi->get_m(), mi->get_d(), &opt, NULL, &cam, mjCAT_ALL, &scn);
     mi->dMutex.unlock();
 }
@@ -530,8 +525,8 @@ std::size_t sensorInterface::hash()
     str += "\ndim=";
     for(auto& dimItem: dim) str += to_string(dimItem) + ",";
 
-    str += "\naddr=";
-    for(auto& addrItem: addr) str += to_string(addrItem) + ",";
+/*     str += "\naddr=";
+    for(auto& addrItem: addr) str += to_string(addrItem) + ","; */
 
     std::hash<std::string> hasher;
     return hasher(str);

--- a/src/mj.hpp
+++ b/src/mj.hpp
@@ -27,7 +27,7 @@ class sensorInterface
     unsigned scalarCount; // number of individual data count. imu and rangefinder would give 4 scalars
     std::vector<std::string> names;
     std::vector<unsigned> dim;
-    std::vector<unsigned> addr;
+    // Sensor adress vector removed
 
     std::size_t hash();
 };
@@ -111,7 +111,7 @@ public:
     std::atomic<bool> shouldCameraRenderNow = false;
 
     void step(std::vector<double> u);
-    std::vector<double> getSensor(unsigned index);
+    std::vector<double> getSensor();
     size_t getCameraRGB(uint8_t *buffer);
     void getCameraDepth(float *buffer);
 };

--- a/src/mj_sfun.cpp
+++ b/src/mj_sfun.cpp
@@ -579,20 +579,18 @@ static void mdlOutputs(SimStruct *S, int_T tid)
     // Copy sensors to output
     real_T *y = ssGetOutputPortRealSignal(S, SENSOR_PORT_INDEX);
     int_T ny = ssGetOutputPortWidth(S, SENSOR_PORT_INDEX);
-    int_T index = 0;
 
     auto nSensors = miTemp->si.count;
+
+    vector<double> yVec = miTemp->getSensor();
     for(int_T i=0; i<nSensors; i++)
     {
-        vector<double> yVec = miTemp->getSensor(i);
-        for(auto elem: yVec)
-        {
-            y[index] = elem;
-            index++;
-            // TODO add a check in case index exceeds the allowed limit
-        }
+
+        y[i] = yVec[i];
+            
     }
-    y[index] = static_cast<double>(nSensors); // last element is a dummy to handle empty sensor case
+
+    y[yVec.size()] = static_cast<double>(nSensors); // last element is a dummy to handle empty sensor case
 
     // Render camera based on the current states. mdlupdate will be called after mdloutputs and update moves the time tk to tk+1
     if(miTemp->offscreenCam.size() != 0)


### PR DESCRIPTION
Since the sensors are read sequentially from the .xml file and the sensor addresses also increase sequentially, the part responsible for fetching sensor addresses in `getSensorInterface()` within `mj.cpp` has been removed. 
Instead, all `d->sensordata` values in `getSensor()` have been updated to be copied directly to the `sensorData` vector, and the output is written directly in `mj_sfun.cpp`.